### PR TITLE
Make code compatible with Python3 (+ small bugfix)

### DIFF
--- a/pynaf/__init__.py
+++ b/pynaf/__init__.py
@@ -160,7 +160,7 @@ class NAFDocument:
             self.text = etree.SubElement(self.root, self.TEXT_LAYER_TAG)
 
         terms_layer = self.tree.find(self.TERMS_LAYER_TAG)
-        if text_layer is not None and len(terms_layer):
+        if terms_layer is not None and len(terms_layer):
             self.terms = terms_layer
         else:
             self.terms = None

--- a/pynaf/__init__.py
+++ b/pynaf/__init__.py
@@ -290,7 +290,7 @@ class NAFDocument:
         # Prepare the word attributes
         word_attributes = dict(
             (k, v)
-            for (k, v) in kwargs.iteritems()
+            for (k, v) in kwargs.items()
             if k in self.valid_word_attributes)
         word_attributes[self.WORD_ID_ATTRIBUTE] = wid
         # Create a text sub-node for the word and set its attributes

--- a/pynaf/__init__.py
+++ b/pynaf/__init__.py
@@ -122,7 +122,7 @@ class NAFDocument:
             self.tree = etree.parse(file_name)
             self.root = self.tree.getroot()
         elif input_stream:
-            if isinstance(input_stream, unicode):
+            if isinstance(input_stream, str):
                 input_stream = input_stream.encode(encoding)
             self.root = etree.fromstring(input_stream)
             self.tree = etree.ElementTree(self.root)
@@ -716,7 +716,7 @@ class NAFDocument:
 
     def __str__(self):
         self._indent(self.root)
-        return etree.tostring(self.root, encoding=self.encoding)
+        return etree.tostring(self.root, encoding=self.encoding).decode(self.encoding)
 
 
 class KAFDocument(NAFDocument):

--- a/pynaf/__init__.py
+++ b/pynaf/__init__.py
@@ -308,7 +308,7 @@ class NAFDocument:
         """
         results = self.text.find("{0}[@{1}='{2}']".format(
             self.WORD_OCCURRENCE_TAG, self.WORD_ID_ATTRIBUTE, wid))
-        return results and results[0]
+        return results  # and results[0]
 
     def add_term(self, tid, pos=None, lemma=None, morphofeat=None,
                  term_type=None, words=(), external_refs=()):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name='pynaf',
-    version='3.0.0',
+    version='3.0.2',
     author='Rodrigo Agerri',
     author_email='rodrigo.agerri@ehu.eus',
     packages=['pynaf',],


### PR DESCRIPTION
File setup.py declares this module supports Python3: "Programming Language :: Python :: 3.6". But the code is only compatible with Python2. This pull request contains a couple of small fixes to make it compatible with Python3.

I'm not sure it should also be compatible with Python2 or not.

In addition, it contains a small bugfix. 